### PR TITLE
Add admin functionality

### DIFF
--- a/contracts/main/CurveStableSwapMetaNG.vy
+++ b/contracts/main/CurveStableSwapMetaNG.vy
@@ -1928,7 +1928,7 @@ def set_admin(_new_admin: address):
 @external
 def set_new_admin_fee(_new_admin_fee: uint256):
     self._check_admins()
-    assert _new_admin_fee <= 10**10 # dev: more than 100%
+    assert _new_admin_fee <= FEE_DENOMINATOR  # dev: more than 100%
 
     self.admin_fee = _new_admin_fee
     log ApplyNewAdminFee(_new_admin_fee)

--- a/contracts/main/CurveStableSwapMetaNG.vy
+++ b/contracts/main/CurveStableSwapMetaNG.vy
@@ -1927,7 +1927,7 @@ def set_admin(_new_admin: address):
 @external
 def set_new_admin_fee(_new_admin_fee: uint256):
     self._check_admins()
-    assert _new_admin_fee <= MAX_FEE
+    assert _new_admin_fee <= 10**10 # dev: more than 100%
 
     self.admin_fee = _new_admin_fee
     log ApplyNewAdminFee(_new_admin_fee)

--- a/contracts/main/CurveStableSwapMetaNG.vy
+++ b/contracts/main/CurveStableSwapMetaNG.vy
@@ -1235,8 +1235,9 @@ def _meta_add_liquidity(dx: uint256, base_i: int128) -> uint256:
 
 @internal
 def _withdraw_admin_fees():
-
-    fee_receiver: address = factory.fee_receiver()
+    fee_receiver: address = self.admin
+    if fee_receiver == empty(address):
+        fee_receiver = factory.fee_receiver()
     if fee_receiver == empty(address):
         return  # Do nothing.
 

--- a/contracts/main/CurveStableSwapMetaNG.vy
+++ b/contracts/main/CurveStableSwapMetaNG.vy
@@ -193,9 +193,15 @@ event ApplyNewFee:
     fee: uint256
     offpeg_fee_multiplier: uint256
 
+event ApplyNewAdminFee:
+    admin_fee: uint256
+
 event SetNewMATime:
     ma_exp_time: uint256
     D_ma_time: uint256
+
+event SetAdmin:
+    admin: address
 
 
 MAX_COINS: constant(uint256) = 8  # max coins is 8 in the factory
@@ -215,6 +221,7 @@ BASE_COINS: public(immutable(DynArray[address, MAX_COINS]))
 
 math: immutable(Math)
 factory: immutable(Factory)
+admin: public(address)
 coins: public(immutable(DynArray[address, MAX_COINS]))
 asset_type: immutable(uint8)
 pool_contains_rebasing_tokens: immutable(bool)
@@ -224,7 +231,7 @@ stored_balances: uint256[N_COINS]
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
 fee: public(uint256)  # fee * 1e10
 offpeg_fee_multiplier: public(uint256)  # * 1e10
-admin_fee: public(constant(uint256)) = 5000000000
+admin_fee: public(uint256)
 MAX_FEE: constant(uint256) = 5 * 10 ** 9
 
 # ---------------------- Pool Amplification Parameters -----------------------
@@ -373,6 +380,9 @@ def __init__(
     # ----------------- Parameters independent of pool type ------------------
 
     factory = Factory(msg.sender)
+    self.admin = empty(address)
+
+    self.admin_fee = 5000000000
 
     A: uint256 = unsafe_mul(_A, A_PRECISION)
     self.initial_A = A
@@ -836,7 +846,7 @@ def add_liquidity(
             fees[i] = unsafe_div(_dynamic_fee_i * difference, FEE_DENOMINATOR)
 
             # fees[i] * admin_fee / FEE_DENOMINATOR
-            self.admin_balances[i] += unsafe_div(fees[i] * admin_fee, FEE_DENOMINATOR)
+            self.admin_balances[i] += unsafe_div(fees[i] * self.admin_fee, FEE_DENOMINATOR)
             new_balances[i] -= fees[i]
 
         xp: uint256[N_COINS] = self._xp_mem(rates, new_balances)
@@ -910,7 +920,7 @@ def remove_liquidity_one_coin(
     assert dy >= _min_received, "Not enough coins removed"
 
     # fee * admin_fee / FEE_DENOMINATOR
-    self.admin_balances[i] += unsafe_div(fee * admin_fee, FEE_DENOMINATOR)
+    self.admin_balances[i] += unsafe_div(fee * self.admin_fee, FEE_DENOMINATOR)
 
     self._burnFrom(msg.sender, _burn_amount)
 
@@ -979,7 +989,7 @@ def remove_liquidity_imbalance(
         fees[i] = unsafe_div(dynamic_fee * difference, FEE_DENOMINATOR)
 
         # fees[i] * admin_fee / FEE_DENOMINATOR
-        self.admin_balances[i] += unsafe_div(fees[i] * admin_fee, FEE_DENOMINATOR)
+        self.admin_balances[i] += unsafe_div(fees[i] * self.admin_fee, FEE_DENOMINATOR)
 
         new_balances[i] -= fees[i]
 
@@ -1131,7 +1141,7 @@ def __exchange(
 
     # admin_fee = dy_fee * admin_fee / FEE_DENOMINATOR
     self.admin_balances[j] += unsafe_div(
-        unsafe_div(dy_fee * admin_fee, FEE_DENOMINATOR) * PRECISION,
+        unsafe_div(dy_fee * self.admin_fee, FEE_DENOMINATOR) * PRECISION,
         rates[j]  # we can do unsafediv here because we did safediv before
     )
 
@@ -1832,9 +1842,15 @@ def dynamic_fee(i: int128, j: int128) -> uint256:
 # --------------------------- AMM Admin Functions ----------------------------
 
 
+@view
+@internal
+def _check_admins():
+    assert msg.sender == factory.admin() or msg.sender == self.admin  # dev: only admin
+
+
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == factory.admin()  # dev: only owner
+    self._check_admins()
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1857,7 +1873,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == factory.admin()  # dev: only owner
+    self._check_admins()
 
     current_A: uint256 = self._A()
     self.initial_A = current_A
@@ -1871,8 +1887,7 @@ def stop_ramp_A():
 
 @external
 def set_new_fee(_new_fee: uint256, _new_offpeg_fee_multiplier: uint256):
-
-    assert msg.sender == factory.admin()
+    self._check_admins()
 
     # set new fee:
     assert _new_fee <= MAX_FEE
@@ -1892,10 +1907,27 @@ def set_ma_exp_time(_ma_exp_time: uint256, _D_ma_time: uint256):
     @param _ma_exp_time Moving average window for the price oracle. It is time_in_seconds / ln(2).
     @param _D_ma_time Moving average window for the D oracle. It is time_in_seconds / ln(2).
     """
-    assert msg.sender == factory.admin()  # dev: only owner
+    self._check_admins()
     assert unsafe_mul(_ma_exp_time, _D_ma_time) > 0  # dev: 0 in input values
 
     self.ma_exp_time = _ma_exp_time
     self.D_ma_time = _D_ma_time
 
     log SetNewMATime(_ma_exp_time, _D_ma_time)
+
+
+@external
+def set_admin(_new_admin: address):
+    assert msg.sender == factory.admin()  # dev: only owner
+
+    self.admin = _new_admin
+    log SetAdmin(_new_admin)
+
+
+@external
+def set_new_admin_fee(_new_admin_fee: uint256):
+    self._check_admins()
+    assert _new_admin_fee <= MAX_FEE
+
+    self.admin_fee = _new_admin_fee
+    log ApplyNewAdminFee(_new_admin_fee)

--- a/contracts/main/CurveStableSwapMetaNG.vy
+++ b/contracts/main/CurveStableSwapMetaNG.vy
@@ -1928,6 +1928,7 @@ def set_admin(_new_admin: address):
 @external
 def set_new_admin_fee(_new_admin_fee: uint256):
     self._check_admins()
+    # FEE_DENOMINATOR = 1 = 100%
     assert _new_admin_fee <= FEE_DENOMINATOR  # dev: more than 100%
 
     self.admin_fee = _new_admin_fee

--- a/contracts/main/CurveStableSwapNG.vy
+++ b/contracts/main/CurveStableSwapNG.vy
@@ -1833,9 +1833,15 @@ def dynamic_fee(i: int128, j: int128) -> uint256:
 # --------------------------- AMM Admin Functions ----------------------------
 
 
+@view
+@internal
+def _check_admins():
+    assert msg.sender == factory.admin() or msg.sender == self.admin  # dev: only admin
+
+
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == factory.admin() or msg.sender == self.admin  # dev: only admin
+    self._check_admins()
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1858,7 +1864,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == factory.admin() or msg.sender == self.admin  # dev: only admin
+    self._check_admins()
 
     current_A: uint256 = self._A()
     self.initial_A = current_A
@@ -1872,7 +1878,7 @@ def stop_ramp_A():
 
 @external
 def set_new_fee(_new_fee: uint256, _new_offpeg_fee_multiplier: uint256):
-    assert msg.sender == factory.admin() or msg.sender == self.admin  # dev: only admin
+    self._check_admins()
 
     # set new fee:
     assert _new_fee <= MAX_FEE
@@ -1892,7 +1898,7 @@ def set_ma_exp_time(_ma_exp_time: uint256, _D_ma_time: uint256):
     @param _ma_exp_time Moving average window for the price oracle. It is time_in_seconds / ln(2).
     @param _D_ma_time Moving average window for the D oracle. It is time_in_seconds / ln(2).
     """
-    assert msg.sender == factory.admin()  # dev: only owner
+    self._check_admins()
     assert unsafe_mul(_ma_exp_time, _D_ma_time) > 0  # dev: 0 in input values
 
     self.ma_exp_time = _ma_exp_time
@@ -1911,7 +1917,7 @@ def set_admin(_new_admin: address):
 
 @external
 def set_new_admin_fee(_new_admin_fee: uint256):
-    assert msg.sender == factory.admin() or msg.sender == self.admin  # dev: only admin
+    self._check_admins()
     assert _new_admin_fee <= MAX_FEE
 
     self.admin_fee = _new_admin_fee

--- a/contracts/main/CurveStableSwapNG.vy
+++ b/contracts/main/CurveStableSwapNG.vy
@@ -1918,7 +1918,7 @@ def set_admin(_new_admin: address):
 @external
 def set_new_admin_fee(_new_admin_fee: uint256):
     self._check_admins()
-    assert _new_admin_fee <= MAX_FEE
+    assert _new_admin_fee <= 10**10 # dev: more than 100%
 
     self.admin_fee = _new_admin_fee
     log ApplyNewAdminFee(_new_admin_fee)

--- a/contracts/main/CurveStableSwapNG.vy
+++ b/contracts/main/CurveStableSwapNG.vy
@@ -1918,7 +1918,7 @@ def set_admin(_new_admin: address):
 @external
 def set_new_admin_fee(_new_admin_fee: uint256):
     self._check_admins()
-    assert _new_admin_fee <= 10**10 # dev: more than 100%
+    assert _new_admin_fee <= FEE_DENOMINATOR  # dev: more than 100%
 
     self.admin_fee = _new_admin_fee
     log ApplyNewAdminFee(_new_admin_fee)

--- a/contracts/main/CurveStableSwapNG.vy
+++ b/contracts/main/CurveStableSwapNG.vy
@@ -165,7 +165,7 @@ N_COINS_128: immutable(int128)
 PRECISION: constant(uint256) = 10 ** 18
 
 factory: immutable(Factory)
-admin: address
+admin: public(address)
 coins: public(immutable(DynArray[address, MAX_COINS]))
 asset_types: immutable(DynArray[uint8, MAX_COINS])
 pool_contains_rebasing_tokens: immutable(bool)

--- a/contracts/main/CurveStableSwapNG.vy
+++ b/contracts/main/CurveStableSwapNG.vy
@@ -152,7 +152,7 @@ event SetNewMATime:
     D_ma_time: uint256
 
 event SetAdmin:
-    admin: Factory
+    admin: address
 
 
 MAX_COINS: constant(uint256) = 8  # max coins is 8 in the factory
@@ -1904,7 +1904,7 @@ def set_admin(_new_admin: Factory):
     assert msg.sender == factory.admin()  # dev: only owner
 
     self.admin = _new_admin
-    log SetAdmin(_new_admin)
+    log SetAdmin(_new_admin.address)
 
 
 @external

--- a/contracts/main/CurveStableSwapNG.vy
+++ b/contracts/main/CurveStableSwapNG.vy
@@ -1918,6 +1918,7 @@ def set_admin(_new_admin: address):
 @external
 def set_new_admin_fee(_new_admin_fee: uint256):
     self._check_admins()
+    # FEE_DENOMINATOR = 1 = 100%
     assert _new_admin_fee <= FEE_DENOMINATOR  # dev: more than 100%
 
     self.admin_fee = _new_admin_fee

--- a/tests/pools/general/test_internal_check_admins.py
+++ b/tests/pools/general/test_internal_check_admins.py
@@ -1,0 +1,17 @@
+import boa
+
+
+def test_default_behavior_factory_admin(swap, owner):
+    swap.internal._check_admins(sender=owner)
+
+
+def test_default_behavior_custom_admin(swap):
+    alice = boa.env.generate_address("alice")
+    swap.eval(f"self.admin = {alice}")
+
+    swap.internal._check_admins(sender=alice)
+
+
+def test_only_admin(swap):
+    with boa.reverts(dev="only admin"):
+        swap.internal._check_admins()

--- a/tests/pools/general/test_ramp_A.py
+++ b/tests/pools/general/test_ramp_A.py
@@ -76,7 +76,7 @@ def test_stop_ramp_A(owner, swap):
 
 
 def test_ramp_A_only_owner(bob, swap):
-    with boa.reverts():
+    with boa.reverts(dev="only admin"):
         swap.ramp_A(0, boa.env.evm.patch.timestamp + 1000000, sender=bob)
 
 
@@ -86,5 +86,5 @@ def test_ramp_A_insufficient_time(owner, swap):
 
 
 def test_stop_ramp_A_only_owner(bob, swap):
-    with boa.reverts():
+    with boa.reverts(dev="only admin"):
         swap.stop_ramp_A(sender=bob)

--- a/tests/pools/general/test_set_new_admin_fee.py
+++ b/tests/pools/general/test_set_new_admin_fee.py
@@ -1,0 +1,18 @@
+import boa
+import pytest
+
+
+@pytest.mark.parametrize("admin_fee", [0, 10**2, 10**6, 10**10])
+def test_default_behavior(admin_fee, swap, owner):
+    swap.set_new_admin_fee(admin_fee, sender=owner)
+    assert swap.admin_fee() == admin_fee
+
+
+def test_only_admin(swap):
+    with boa.reverts(dev="only admin"):
+        swap.set_new_admin_fee(10**2)
+
+
+def test_max_admin_fee(swap, owner):
+    with boa.reverts(dev="more than 100%"):
+        swap.set_new_admin_fee(10**10 + 1, sender=owner)


### PR DESCRIPTION
# About
## Admin functionality
Some pools may be delegated to other protocols for agile management.

## Mutable admin fee
Some protocols give benefits to Curve DAO implicitly, so we can giveaway generated fees.
For example, crosscurve uses lp tokens of other pools, so we can give them fees from the hub pool.

# What I did
Added admin role, that is set as a `fee_receiver` and is able to update pool parameters:
- ramp/stop ramp `A`
- `fee` and `offpeg_fee_multiplier`
- `admin_fee`
Though, OG factory is saved, so only original owner can decide on the pool admins. This way DAO can verify that only some set of parameters can be updated.